### PR TITLE
Place init statements in their proper location in AutoState classes

### DIFF
--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/AngleAutonomous.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/AngleAutonomous.java
@@ -23,11 +23,15 @@ public class AngleAutonomous extends AutoState {
 	public AngleAutonomous(double angle, double speed, IGyro gyro) {
 		this.gyro = gyro;
 		this.speed = speed;
-		this.currAngle = gyro.getAngle();
-		this.endAngle = currAngle + angle;
 		this.deltaAngle = angle;
 	}
 
+	@Override
+	public void init() {
+		this.currAngle = gyro.getAngle();
+		this.endAngle = currAngle + deltaAngle;
+	}
+	
 	@Override
 	public boolean shouldChange() {
 		if (deltaAngle > 0) { // clockwise

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/DistanceAutonomous.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/DistanceAutonomous.java
@@ -18,7 +18,11 @@ public class DistanceAutonomous extends AutoState {
 		this.distance = distance;
 		this.speed = speed;
 		this.encoder = encoder;
-		this.encoderZeroPoint = encoder.getDistance(); 
+	}
+	
+	@Override
+	public void init(){
+		this.encoderZeroPoint = encoder.getDistance(); 		
 	}
 	
 	@Override

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/ForwardAutonomous.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/ForwardAutonomous.java
@@ -9,9 +9,12 @@ public class ForwardAutonomous extends AutoState {
 	double speed = 1;
 	
 	public ForwardAutonomous(int millis, double speed) {
-		timeStart = System.nanoTime();
 		this.timeLimit = millis;
 		this.speed = speed;
+	}
+	
+	public void init() {
+		timeStart = System.nanoTime();
 	}
 	
 	public ForwardAutonomous(int millis) {

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/RotateAutonomous.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/RotateAutonomous.java
@@ -11,10 +11,14 @@ public class RotateAutonomous extends AutoState {
 	TurnDirection turnDirection;
 
 	public RotateAutonomous(int millis, double speed, TurnDirection turnDirection) {
-		timeStart = System.nanoTime();
 		this.timeLimit = millis;
 		this.speed = speed;
 		this.turnDirection = turnDirection;
+	}
+	
+	public void init() {
+		timeStart = System.nanoTime();
+
 	}
 	
 	public RotateAutonomous(int millis, TurnDirection turnDirection) {

--- a/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/AngleAutonomousTest.java
+++ b/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/AngleAutonomousTest.java
@@ -27,9 +27,11 @@ public class AngleAutonomousTest {
 	public void testShouldNotChange() {
 		gyro.reset();
 		AutoState autoClock = new AngleAutonomous(2*PI, 0.1, gyro);
+		autoClock.init();
 		assertEquals(false, autoClock.shouldChange());
 		
 		AutoState autoCounterclock = new AngleAutonomous(-2*PI, 0.1, gyro);
+		autoCounterclock.init();
 		assertEquals(false, autoCounterclock.shouldChange());
 	}
 	
@@ -37,7 +39,7 @@ public class AngleAutonomousTest {
 	public void testClockwiseRotation() {
 		gyro.reset();
 		AngleAutonomous auto = new AngleAutonomous(PI/4, 1, gyro);
-		
+		auto.init();
 		auto.driveTrainSpeed();
 		gyro.currAngle = PI/4;
 		auto.driveTrainSpeed();
@@ -50,7 +52,7 @@ public class AngleAutonomousTest {
 	public void testCounterClockwiseRotation() {
 		gyro.reset();
 		AngleAutonomous auto = new AngleAutonomous(-PI/4, 1, gyro);
-
+		auto.init();
 		auto.driveTrainSpeed();
 		gyro.currAngle = -PI/4;
 		auto.driveTrainSpeed();

--- a/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/DistanceAutonomousTest.java
+++ b/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/DistanceAutonomousTest.java
@@ -35,6 +35,7 @@ public class DistanceAutonomousTest {
 	public void testFixedDistanceTraveled() {
 		encoder.reset();
 		DistanceAutonomous auto = new DistanceAutonomous(1.5, 1, encoder);
+		auto.init();
 		MotorOutput motorOutput = auto.driveTrainSpeed();
 		
 		// We haven't driven far enough yet, so the robot should still be moving.
@@ -58,6 +59,7 @@ public class DistanceAutonomousTest {
 		for (double speed = 0.0; speed < 1.0; speed += 0.3) {
 			encoder.reset();
 			DistanceAutonomous auto = new DistanceAutonomous(1, speed, encoder);
+			auto.init();
 			auto.driveTrainSpeed();
 			
 			encoder.distance = speed;
@@ -73,12 +75,14 @@ public class DistanceAutonomousTest {
 		encoder.reset();
 		
 		DistanceAutonomous auto = new DistanceAutonomous(1.5, 1, encoder);
+		auto.init();
 		auto.driveTrainSpeed();
 		assertEquals(false, auto.shouldChange());
 		encoder.distance = 1.5;
 		assertEquals(true, auto.shouldChange());
 		
 		auto = new DistanceAutonomous(1.5, 1, encoder);
+		auto.init();
 		auto.driveTrainSpeed();
 		assertEquals(false, auto.shouldChange());
 		encoder.distance = 3;

--- a/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/ForwardAutonomousTest.java
+++ b/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/ForwardAutonomousTest.java
@@ -22,12 +22,14 @@ public class ForwardAutonomousTest {
 	@Test
 	public void testShouldNotChange() {
 		AutoState auto = new ForwardAutonomous(1000);
+		auto.init();
 		assertEquals(false, auto.shouldChange());
 	}
 	
 	@Test
 	public void testForwardMotion() {
 		AutoState auto = new ForwardAutonomous(1000);
+		auto.init();
 		MotorOutput motorOutput = auto.driveTrainSpeed();
 		assertEquals(1, motorOutput.left, EPSILON);
 		assertEquals(1, motorOutput.right, EPSILON);


### PR DESCRIPTION
This fixes an issue in which variables in the Autonomous classes would use the wrong data. For example, the current time would be gotten when the object was constructured but not when run. This PR fixes that.
