### PR TITLE
Make ForwardAutonomous use gyros

### DIFF
--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/ForwardAutonomous.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/ForwardAutonomous.java
@@ -1,16 +1,26 @@
 package org.usfirst.frc.team1076.robot.statemachine;
 
 import org.usfirst.frc.team1076.robot.gamepad.IDriverInput.MotorOutput;
+import org.usfirst.frc.team1076.robot.sensors.IGyro;
+
 import java.util.concurrent.TimeUnit;
 
 public class ForwardAutonomous extends AutoState {
+	private static final double TOLERANCE = 0.05;
+	private static final double CORRECTION_FACTOR_CONST = 10.0;
 	long timeStart;
 	long timeLimit;
 	double speed = 1;
+	private IGyro gyro;
 	
-	public ForwardAutonomous(int millis, double speed) {
+	public ForwardAutonomous(int millis, double speed, IGyro gyro) {
 		this.timeLimit = millis;
 		this.speed = speed;
+		this.gyro = gyro;
+	}
+	
+	public ForwardAutonomous(int millis, double speed) {
+		this(millis, speed, null);
 	}
 	
 	public void init() {
@@ -28,10 +38,25 @@ public class ForwardAutonomous extends AutoState {
 	
 	@Override
 	public MotorOutput driveTrainSpeed() {
+		double rate;
+		if (gyro != null) {
+			rate = gyro.getRate();
+		} else {
+			rate = 0;
+		}
 		if (shouldChange()) {
 			return new MotorOutput(0, 0);
+		} else if(rate > TOLERANCE) {
+			return new MotorOutput(speed, speed * getCorrectionFactor(rate));
+		} else if(rate < -TOLERANCE) {
+			return new MotorOutput(speed * getCorrectionFactor(rate), speed);
 		} else {
 			return new MotorOutput(speed, speed);
 		}
+	}
+	
+	// TODO: Find a reasonable function for this.
+	public double getCorrectionFactor(double rate) {
+		return CORRECTION_FACTOR_CONST / (CORRECTION_FACTOR_CONST + Math.abs(rate));
 	}
 }

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/ForwardAutonomous.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/ForwardAutonomous.java
@@ -47,9 +47,9 @@ public class ForwardAutonomous extends AutoState {
 		if (shouldChange()) {
 			return new MotorOutput(0, 0);
 		} else if(rate > TOLERANCE) {
-			return new MotorOutput(speed, speed * getCorrectionFactor(rate));
-		} else if(rate < -TOLERANCE) {
 			return new MotorOutput(speed * getCorrectionFactor(rate), speed);
+		} else if(rate < -TOLERANCE) {
+			return new MotorOutput(speed, speed * getCorrectionFactor(rate));
 		} else {
 			return new MotorOutput(speed, speed);
 		}

--- a/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/ForwardAutonomousTest.java
+++ b/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/ForwardAutonomousTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.usfirst.frc.team1076.robot.gamepad.IDriverInput.MotorOutput;
 import org.usfirst.frc.team1076.robot.statemachine.ForwardAutonomous;
 import org.usfirst.frc.team1076.robot.statemachine.AutoState;
+import org.usfirst.frc.team1076.test.mock.MockGyro;
 
 public class ForwardAutonomousTest {
 	private static final double EPSILON = 1e-12;
@@ -27,12 +28,35 @@ public class ForwardAutonomousTest {
 	}
 	
 	@Test
-	public void testForwardMotion() {
+	public void testNoGyroForwardMotion() {
 		AutoState auto = new ForwardAutonomous(1000);
 		auto.init();
 		MotorOutput motorOutput = auto.driveTrainSpeed();
 		assertEquals(1, motorOutput.left, EPSILON);
 		assertEquals(1, motorOutput.right, EPSILON);
+	}
+	
+	@Test
+	public void testGyroClockwiseForwardMotion() {
+		MockGyro gyro = new MockGyro();
+		gyro.gyroRate = 2;
+		AutoState auto = new ForwardAutonomous(1000, 1, gyro);
+		auto.init();
+		MotorOutput motorOutput = auto.driveTrainSpeed();
+		assertEquals(motorOutput.left, 1 , EPSILON);
+		assertEquals(motorOutput.right, 5.0 / 6.0, EPSILON);
+	}
+
+	@Test
+	public void testGyroCounterclockwiseMotion() {
+		MockGyro gyro = new MockGyro();
+		gyro.gyroRate = -2;
+		AutoState auto = new ForwardAutonomous(1000, 1, gyro);
+		auto.init();
+		MotorOutput motorOutput = auto.driveTrainSpeed();
+		System.out.println(motorOutput.left);
+		assertEquals(motorOutput.left, 5.0 / 6.0, EPSILON);
+		assertEquals(motorOutput.right, 1, EPSILON);
 	}
 	
 	@Test

--- a/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/ForwardAutonomousTest.java
+++ b/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/ForwardAutonomousTest.java
@@ -43,8 +43,8 @@ public class ForwardAutonomousTest {
 		AutoState auto = new ForwardAutonomous(1000, 1, gyro);
 		auto.init();
 		MotorOutput motorOutput = auto.driveTrainSpeed();
-		assertEquals(motorOutput.left, 1 , EPSILON);
-		assertEquals(motorOutput.right, 5.0 / 6.0, EPSILON);
+		assertEquals(motorOutput.left, 5.0 / 6.0, EPSILON);
+		assertEquals(motorOutput.right, 1, EPSILON);
 	}
 
 	@Test
@@ -55,8 +55,8 @@ public class ForwardAutonomousTest {
 		auto.init();
 		MotorOutput motorOutput = auto.driveTrainSpeed();
 		System.out.println(motorOutput.left);
-		assertEquals(motorOutput.left, 5.0 / 6.0, EPSILON);
-		assertEquals(motorOutput.right, 1, EPSILON);
+		assertEquals(motorOutput.left, 1, EPSILON);
+		assertEquals(motorOutput.right, 5.0 / 6.0, EPSILON);
 	}
 	
 	@Test


### PR DESCRIPTION
ForwardAutonomous gets the current rate of the gyro and uses that information to slow the motor which is running faster.
If no gyro is passed, the correction system is not used.
The correction factor used still needs testing.
