### PR TITLE
Refactor IEncoder into IDistanceEncoder

### DIFF
--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/sensors/DistanceEncoder.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/sensors/DistanceEncoder.java
@@ -2,10 +2,9 @@ package org.usfirst.frc.team1076.robot.sensors;
 
 import org.usfirst.frc.team1076.robot.sensors.GearShiftStateManager.GearStates;
 
-public class DistanceEncoder implements IEncoder {	
+public class DistanceEncoder implements IDistanceEncoder {	
 	IEncoder encoder;
 	GearShiftStateManager gearShifter;
-	GearStates currentGear;
 	double countAccumulator = 0; 
 	double totalDistance = 0;
 	
@@ -18,14 +17,13 @@ public class DistanceEncoder implements IEncoder {
 	public DistanceEncoder(IEncoder encoder, GearShiftStateManager gearShifter) {
 		this.encoder = encoder;
 		this.gearShifter = gearShifter;
-		this.currentGear = gearShifter.getGearState();
 	}
 	
 	public void updateDistance() {
 		// This function should be called often.
 		double deltaCount = getRaw() - countAccumulator;
 		double deltaDistance = deltaCount * MOTOR_PERIOD * WHEEL_CIRCUMFRENCE;
-		currentGear = gearShifter.getGearState();
+		GearStates currentGear = gearShifter.getGearState();
 		countAccumulator = getRaw();
 		
 		// Add the distance traveled since last time we checked.
@@ -51,7 +49,6 @@ public class DistanceEncoder implements IEncoder {
 		encoder.reset();
 		countAccumulator = 0;
 		totalDistance = 0;
-		currentGear = null;
 	}
 
 	@Override

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/sensors/IDistanceEncoder.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/sensors/IDistanceEncoder.java
@@ -1,0 +1,5 @@
+package org.usfirst.frc.team1076.robot.sensors;
+
+public interface IDistanceEncoder extends IEncoder {
+	double getDistance();
+}

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/sensors/IEncoder.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/sensors/IEncoder.java
@@ -1,7 +1,6 @@
 package org.usfirst.frc.team1076.robot.sensors;
 
 public interface IEncoder {
-	double getDistance();
 	double getRate();
 	double getRaw();
 	void reset();

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/DistanceAutonomous.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/DistanceAutonomous.java
@@ -1,7 +1,7 @@
 package org.usfirst.frc.team1076.robot.statemachine;
 
 import org.usfirst.frc.team1076.robot.gamepad.IDriverInput.MotorOutput;
-import org.usfirst.frc.team1076.robot.sensors.IEncoder;
+import org.usfirst.frc.team1076.robot.sensors.IDistanceEncoder;
 
 /**
  * DistanceAutonomous takes a distance and speed parameter and outputs
@@ -9,12 +9,12 @@ import org.usfirst.frc.team1076.robot.sensors.IEncoder;
  * encoder to tell how far it has driven.
  * */
 public class DistanceAutonomous extends AutoState {
-	IEncoder encoder;
+	IDistanceEncoder encoder;
 	double encoderZeroPoint;
 	double speed;
 	double distance;
 
-	public DistanceAutonomous(double distance, double speed, IEncoder encoder) {
+	public DistanceAutonomous(double distance, double speed, IDistanceEncoder encoder) {
 		this.distance = distance;
 		this.speed = speed;
 		this.encoder = encoder;

--- a/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/mock/MockEncoder.java
+++ b/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/mock/MockEncoder.java
@@ -1,8 +1,8 @@
 package org.usfirst.frc.team1076.test.mock;
 
-import org.usfirst.frc.team1076.robot.sensors.IEncoder;
+import org.usfirst.frc.team1076.robot.sensors.IDistanceEncoder;
 
-public class MockEncoder implements IEncoder {
+public class MockEncoder implements IDistanceEncoder {
 	public double distance;
 	public double rawCount;
 	public double encoderRate;


### PR DESCRIPTION
Most encoders cannot respond to `getDistance()` sensibly. This PR makes it so that they don't have to try to anymore.

`getDistance` has been moved from `IEncoder` into `IDistanceEncoder`

`MockEncoder` and `DistanceEncoder` now implement `IDistanceEncoder`.
