### PR TITLE
[Limit Switches] Use soft limits and limit switches in the lift arm.

### DIFF
--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -131,28 +131,38 @@ public class Robot extends IterativeRobot implements IRobot {
 		armMotor.ConfigFwdLimitSwitchNormallyOpen(true);
 		armMotor.ConfigRevLimitSwitchNormallyOpen(true);
 		armMotor.enableLimitSwitch(true, true);
-		armExtendMotor.ConfigFwdLimitSwitchNormallyOpen(true);
-		armExtendMotor.ConfigRevLimitSwitchNormallyOpen(true);
-		armExtendMotor.enableLimitSwitch(true, true);
+        armFollower.ConfigFwdLimitSwitchNormallyOpen(true);
+        armFollower.ConfigRevLimitSwitchNormallyOpen(true);
+        armFollower.enableLimitSwitch(true, true);
+        armExtendMotor.ConfigFwdLimitSwitchNormallyOpen(true);
+        armExtendMotor.ConfigRevLimitSwitchNormallyOpen(true);
+        armExtendMotor.enableLimitSwitch(true, true);
+		armExtendFollower.ConfigFwdLimitSwitchNormallyOpen(true);
+		armExtendFollower.ConfigRevLimitSwitchNormallyOpen(true);
+		armExtendFollower.enableLimitSwitch(true, true);
 		// leftFollower.changeControlMode(TalonControlMode.Follower);
 		// leftFollower.set(LEFT_INDEX);
 
-		// These are the physical limit switches. By default it
-		// initalizes in the "normally open" state.
-		armMotor.enableLimitSwitch(true, true);
-		armFollower.enableLimitSwitch(true, true);
 		// Soft Limits are limits which disable the motor if
 		// the "Sensor Position" (the encoder) is outside a certain range
 		// This is disabled in teleop.
 		// TODO: Find true soft limits
 		armMotor.setForwardSoftLimit(10000);
-		armMotor.setReverseSoftLimit(10000);
+		armMotor.setReverseSoftLimit(-10000);
 		armMotor.enableForwardSoftLimit(true);
 		armMotor.enableReverseSoftLimit(true);
-		armExtendMotor.setForwardSoftLimit(-10000);
+        armFollower.setForwardSoftLimit(10000);
+        armFollower.setReverseSoftLimit(-10000);
+        armFollower.enableForwardSoftLimit(true);
+        armFollower.enableReverseSoftLimit(true);
+		armExtendMotor.setForwardSoftLimit(10000);
 		armExtendMotor.setReverseSoftLimit(-10000);
 		armExtendMotor.enableForwardSoftLimit(true);
 		armExtendMotor.enableReverseSoftLimit(true);
+		armExtendFollower.setForwardSoftLimit(10000);
+		armExtendFollower.setReverseSoftLimit(-10000);
+		armExtendFollower.enableForwardSoftLimit(true);
+		armExtendFollower.enableReverseSoftLimit(true);
 		
 		compressor.setClosedLoopControl(true);
 		setIntakeElevation(IntakeRaiseState.Raised);
@@ -240,8 +250,12 @@ public class Robot extends IterativeRobot implements IRobot {
     	// Disabling the soft limits still keeps the limit switch working.
         armMotor.enableForwardSoftLimit(false);
         armMotor.enableReverseSoftLimit(false);
+        armFollower.enableForwardSoftLimit(false);
+        armFollower.enableReverseSoftLimit(false);
         armExtendMotor.enableForwardSoftLimit(false);
         armExtendMotor.enableReverseSoftLimit(false);
+        armExtendFollower.enableForwardSoftLimit(false);
+        armExtendFollower.enableReverseSoftLimit(false);
 
     	if (teleopController != null) {
     		teleopController.teleopInit(this);

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -136,6 +136,23 @@ public class Robot extends IterativeRobot implements IRobot {
 		armExtendMotor.enableLimitSwitch(true, true);
 		// leftFollower.changeControlMode(TalonControlMode.Follower);
 		// leftFollower.set(LEFT_INDEX);
+
+		// These are the physical limit switches. By default it
+		// initalizes in the "normally open" state.
+		armMotor.enableLimitSwitch(true, true);
+		armFollower.enableLimitSwitch(true, true);
+		// Soft Limits are limits which disable the motor if
+		// the "Sensor Position" (the encoder) is outside a certain range
+		// This is disabled in teleop.
+		// TODO: Find true soft limits
+		armMotor.setForwardSoftLimit(10000);
+		armMotor.setReverseSoftLimit(10000);
+		armMotor.enableForwardSoftLimit(true);
+		armMotor.enableReverseSoftLimit(true);
+		armExtendMotor.setForwardSoftLimit(-10000);
+		armExtendMotor.setReverseSoftLimit(-10000);
+		armExtendMotor.enableForwardSoftLimit(true);
+		armExtendMotor.enableReverseSoftLimit(true);
 		
 		compressor.setClosedLoopControl(true);
 		setIntakeElevation(IntakeRaiseState.Raised);
@@ -220,7 +237,12 @@ public class Robot extends IterativeRobot implements IRobot {
     @Override
     public void teleopInit() {
     	lidarMotorSpeed = SmartDashboard.getNumber("Initial Lidar Speed");
-    	
+    	// Disabling the soft limits still keeps the limit switch working.
+        armMotor.enableForwardSoftLimit(false);
+        armMotor.enableReverseSoftLimit(false);
+        armExtendMotor.enableForwardSoftLimit(false);
+        armExtendMotor.enableReverseSoftLimit(false);
+
     	if (teleopController != null) {
     		teleopController.teleopInit(this);
     	} else {

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -127,6 +127,13 @@ public class Robot extends IterativeRobot implements IRobot {
 		armFollower.enableBrakeMode(true);
 		armExtendMotor.enableBrakeMode(true);
 		armExtendFollower.enableBrakeMode(true);
+		
+		armMotor.ConfigFwdLimitSwitchNormallyOpen(true);
+		armMotor.ConfigRevLimitSwitchNormallyOpen(true);
+		armMotor.enableLimitSwitch(true, true);
+		armExtendMotor.ConfigFwdLimitSwitchNormallyOpen(true);
+		armExtendMotor.ConfigRevLimitSwitchNormallyOpen(true);
+		armExtendMotor.enableLimitSwitch(true, true);
 		// leftFollower.changeControlMode(TalonControlMode.Follower);
 		// leftFollower.set(LEFT_INDEX);
 		


### PR DESCRIPTION
Soft limits are enabled while in autonomous and disabled in teleop. Limit switches are alway set to "normally open".

Using both soft limits and limits switches requires an encoder and a limit switch but is a cleaner solution.

It also means there is no switching between normally open and normally closed.

Merge this one if encoders are put onto the lift arm.
- [ ] TODO: TEST THIS ON THE ROBOT!

Should resolve #48.
