### PR TITLE
[Limit Switches] Use only limit switches on the lift arm.

### DIFF
--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -132,9 +132,15 @@ public class Robot extends IterativeRobot implements IRobot {
 		armMotor.ConfigFwdLimitSwitchNormallyOpen(true);
 		armMotor.ConfigRevLimitSwitchNormallyOpen(true);
 		armMotor.enableLimitSwitch(true, true);
+		armFollower.ConfigFwdLimitSwitchNormallyOpen(true);
+		armFollower.ConfigRevLimitSwitchNormallyOpen(true);
+		armFollower.enableLimitSwitch(true, true);
 		armExtendMotor.ConfigFwdLimitSwitchNormallyOpen(true);
 		armExtendMotor.ConfigRevLimitSwitchNormallyOpen(true);
 		armExtendMotor.enableLimitSwitch(true, true);
+		armExtendFollower.ConfigFwdLimitSwitchNormallyOpen(true);
+		armExtendFollower.ConfigRevLimitSwitchNormallyOpen(true);
+		armExtendFollower.enableLimitSwitch(true, true);
 		// leftFollower.changeControlMode(TalonControlMode.Follower);
 		// leftFollower.set(LEFT_INDEX);
 		

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -127,6 +127,7 @@ public class Robot extends IterativeRobot implements IRobot {
 		armFollower.enableBrakeMode(true);
 		armExtendMotor.enableBrakeMode(true);
 		armExtendFollower.enableBrakeMode(true);
+
 		
 		armMotor.ConfigFwdLimitSwitchNormallyOpen(true);
 		armMotor.ConfigRevLimitSwitchNormallyOpen(true);
@@ -167,6 +168,11 @@ public class Robot extends IterativeRobot implements IRobot {
 	 */
 	@Override
     public void autonomousInit() {
+	    // Setting the limit switch to be normally closed
+	    // ensures that the motors will disable if the limit switches break.
+	    armMotor.ConfigFwdLimitSwitchNormallyOpen(false);
+	    armFollower.ConfigFwdLimitSwitchNormallyOpen(false);
+
 		sensorData.sendAttackColor("tegra-ubuntu:5888", SmartDashboard.getString("Enemy Color"));
 		
 		if (SmartDashboard.getBoolean("Auto Program Enabled")) {
@@ -219,6 +225,12 @@ public class Robot extends IterativeRobot implements IRobot {
 
     @Override
     public void teleopInit() {
+        // Setting the limit switches to be normally open
+        // ensures the motor always works even when the limit switch
+        // does not work. Note that this will cause a brief disabling of the arm.
+        armMotor.ConfigFwdLimitSwitchNormallyOpen(true);
+        armFollower.ConfigFwdLimitSwitchNormallyOpen(true);
+
     	lidarMotorSpeed = SmartDashboard.getNumber("Initial Lidar Speed");
     	
     	if (teleopController != null) {

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -127,6 +127,13 @@ public class Robot extends IterativeRobot implements IRobot {
 		armFollower.enableBrakeMode(true);
 		armExtendMotor.enableBrakeMode(true);
 		armExtendFollower.enableBrakeMode(true);
+		
+		armMotor.ConfigFwdLimitSwitchNormallyOpen(true);
+		armMotor.ConfigRevLimitSwitchNormallyOpen(true);
+		armMotor.enableLimitSwitch(true, true);
+		armExtendMotor.ConfigFwdLimitSwitchNormallyOpen(true);
+		armExtendMotor.ConfigRevLimitSwitchNormallyOpen(true);
+		armExtendMotor.enableLimitSwitch(true, true);
 		// leftFollower.changeControlMode(TalonControlMode.Follower);
 		// leftFollower.set(LEFT_INDEX);
 		


### PR DESCRIPTION
Limit switches are set to "normally closed" in autonomous and are changed to "normally open" in teleop. This comes with a brief delay when switching between the two settings.

Merge this if all we have are limit switches on the lift arm.
- [ ] TODO: TEST THIS ON THE ROBOT!

Should resolve #48.
