### PR TITLE
Post MARC changes.

### DIFF
--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/IRobot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/IRobot.java
@@ -17,4 +17,5 @@ public interface IRobot {
 	void setGear(SolenoidValue value);
 	MotorOutput getMotorSpeed();
 	void setArmSpeed(double speed, boolean turbo);
+	void setArmSpeed(double speed, boolean turbo, boolean operatorTurbo);
 }

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/IRobot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/IRobot.java
@@ -16,4 +16,5 @@ public interface IRobot {
 	ISensorData getSensorData(); 
 	void setGear(SolenoidValue value);
 	MotorOutput getMotorSpeed();
+	void setArmSpeed(double speed, boolean turbo);
 }

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/IRobot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/IRobot.java
@@ -16,10 +16,4 @@ public interface IRobot {
 	ISensorData getSensorData(); 
 	void setGear(SolenoidValue value);
 	MotorOutput getMotorSpeed();
-	void setArmSpeed(double speed, boolean turbo);
-	void setArmSpeed(double speed, boolean turbo, boolean operatorTurbo);
-    double getArmDownSpeed();
-    double getArmUpSpeed();
-    double getArmTurboSpeed();
-    double getArmOperatorTurboSpeed();
 }

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/IRobot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/IRobot.java
@@ -18,4 +18,8 @@ public interface IRobot {
 	MotorOutput getMotorSpeed();
 	void setArmSpeed(double speed, boolean turbo);
 	void setArmSpeed(double speed, boolean turbo, boolean operatorTurbo);
+    double getArmDownSpeed();
+    double getArmUpSpeed();
+    double getArmTurboSpeed();
+    double getArmOperatorTurboSpeed();
 }

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/controllers/AutoController.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/controllers/AutoController.java
@@ -40,6 +40,7 @@ public class AutoController implements IRobotController {
 			autoState.init(); // Initialize the new autonomous mode
 		}
 		robot.setArmSpeed(autoState.armSpeed());
+		robot.setArmExtendSpeed(autoState.armExtendSpeed());
 		robot.setIntakeSpeed(autoState.intakeSpeed());
 		MotorOutput drive = autoState.driveTrainSpeed();
 		robot.setLeftSpeed(drive.left);

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/controllers/TeleopController.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/controllers/TeleopController.java
@@ -35,7 +35,11 @@ public class TeleopController implements IRobotController {
 	
 	@Override
 	public void teleopPeriodic(IRobot robot) {
-		robot.setArmSpeed(operatorInput.armSpeed());
+		if (driverInput.turboArm()) {
+			robot.setArmSpeed(operatorInput.armSpeed(), true);
+		} else {
+			robot.setArmSpeed(operatorInput.armSpeed(), false);
+		}
 		robot.setArmExtendSpeed(operatorInput.armExtendSpeed());
 		robot.setIntakeSpeed(operatorInput.intakeSpeed());
 		robot.setIntakeElevation(operatorInput.intakeRaiseState());
@@ -55,7 +59,6 @@ public class TeleopController implements IRobotController {
 		default:
 			break;
 		}
-
     	if (driverInput.shiftHigh()) {
     		gearShifter.shiftHigh(robot);
     	} else if (driverInput.shiftLow()) {

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/controllers/TeleopController.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/controllers/TeleopController.java
@@ -37,6 +37,8 @@ public class TeleopController implements IRobotController {
 	public void teleopPeriodic(IRobot robot) {
 		if (driverInput.turboArm()) {
 			robot.setArmSpeed(operatorInput.armSpeed(), true);
+		} else if (operatorInput.operatorTurbo()){
+			robot.setArmSpeed(operatorInput.armSpeed(), false, true);
 		} else {
 			robot.setArmSpeed(operatorInput.armSpeed(), false);
 		}

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/controllers/TeleopController.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/controllers/TeleopController.java
@@ -11,6 +11,11 @@ public class TeleopController implements IRobotController {
 	IDriverInput driverInput;
 	IOperatorInput operatorInput;
 	
+	double driverTurboSpeed = 1;
+	double operatorTurboSpeed = 0.75;
+	double armUpSpeed = 0.4;
+	double armDownSpeed = 0.23;
+	
 	GearShifter gearShifter;
 	
 	public TeleopController(IDriverInput driverInput, IOperatorInput operatorInput,
@@ -35,14 +40,29 @@ public class TeleopController implements IRobotController {
 	
 	@Override
 	public void teleopPeriodic(IRobot robot) {
-		if (driverInput.turboArm()) {
-			robot.setArmSpeed(operatorInput.armSpeed(), true);
-		} else if (operatorInput.operatorTurbo()){
-			robot.setArmSpeed(operatorInput.armSpeed(), false, true);
+	    /*
+        Turbo mode increases the power going to the lift arm. This allows
+        the arm to recover from moving too far forwards. The driver has a full
+        power turbo while the operator has a 75% turbo. The driver takes precedence.
+        The turbo mode only applies when lowering the lift arm.
+
+        Note that the raising and lowering of the arm differ in speed even
+        when not in any turbo mode. Lowering is less powerful due to gravity
+        helping. This difference can not be turned off.
+        */
+	    double armSpeed = operatorInput.armSpeed();
+		if (armSpeed > 0) {
+		    robot.setArmSpeed(armSpeed * armUpSpeed);
 		} else {
-			robot.setArmSpeed(operatorInput.armSpeed(), false);
-		}
-		robot.setArmExtendSpeed(operatorInput.armExtendSpeed());
+		    if (driverInput.turboArm()) {
+                robot.setArmSpeed(armSpeed * driverTurboSpeed);
+            } else if (operatorInput.operatorTurbo()) {
+                robot.setArmSpeed(armSpeed * operatorTurboSpeed);
+            } else {
+                robot.setArmSpeed(armSpeed * armDownSpeed);
+            }
+        }
+        robot.setArmExtendSpeed(operatorInput.armExtendSpeed());
 		robot.setIntakeSpeed(operatorInput.intakeSpeed());
 		robot.setIntakeElevation(operatorInput.intakeRaiseState());
 		MotorOutput drive = driverInput.driveTrainSpeed();
@@ -75,4 +95,20 @@ public class TeleopController implements IRobotController {
 
 	@Override
 	public void testPeriodic(IRobot robot) { }
+
+    public double getDriverTurboSpeed() {
+        return driverTurboSpeed;
+    }
+
+    public double getOperatorTurboSpeed() {
+        return operatorTurboSpeed;
+    }
+
+    public double getArmUpSpeed() {
+        return armUpSpeed;
+    }
+
+    public double getArmDownSpeed() {
+        return armDownSpeed;
+    }
 }

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/gamepad/ArcadeInput.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/gamepad/ArcadeInput.java
@@ -49,7 +49,6 @@ public class ArcadeInput implements IDriverInput {
 	}
 
 	public boolean turboArm() {
-		System.out.println("Turbo enabled! (Arcade)");
 		return gamepad.getButton(GamepadButton.B);
 	}
 }

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/gamepad/ArcadeInput.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/gamepad/ArcadeInput.java
@@ -47,4 +47,9 @@ public class ArcadeInput implements IDriverInput {
 			return ControlSide.Current;
 		}
 	}
+
+	public boolean turboArm() {
+		System.out.println("Turbo enabled! (Arcade)");
+		return gamepad.getButton(GamepadButton.B);
+	}
 }

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/gamepad/IDriverInput.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/gamepad/IDriverInput.java
@@ -17,4 +17,5 @@ public interface IDriverInput {
 	
 	enum ControlSide { Left, Right, Current }
 	ControlSide controlSide();
+	boolean turboArm();
 }

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/gamepad/IOperatorInput.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/gamepad/IOperatorInput.java
@@ -8,4 +8,5 @@ public interface IOperatorInput {
 	
 	double armExtendSpeed();
 	double armSpeed();
+	boolean operatorTurbo();
 }

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/gamepad/OperatorInput.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/gamepad/OperatorInput.java
@@ -42,4 +42,10 @@ public class OperatorInput implements IOperatorInput {
 		}		
 		return IntakeRaiseState.Neutral;
 	}
+
+	@Override
+	public boolean operatorTurbo() {
+		return gamepad.getButton(GamepadButton.B);
+	}
 }
+

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/gamepad/OperatorInput.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/gamepad/OperatorInput.java
@@ -17,7 +17,7 @@ public class OperatorInput implements IOperatorInput {
 
 	@Override
 	public double armExtendSpeed() {
-		return gamepad.getAxis(GamepadAxis.LeftY);
+		return -gamepad.getAxis(GamepadAxis.LeftY);
 	}
 	
 	@Override

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/gamepad/OperatorInput.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/gamepad/OperatorInput.java
@@ -17,7 +17,8 @@ public class OperatorInput implements IOperatorInput {
 
 	@Override
 	public double armExtendSpeed() {
-		return -gamepad.getAxis(GamepadAxis.LeftY);
+	    // TODO: Check on actual robot if I can undo this negative symbol.
+		return gamepad.getAxis(GamepadAxis.LeftY);
 	}
 	
 	@Override

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/gamepad/TankInput.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/gamepad/TankInput.java
@@ -44,7 +44,6 @@ public class TankInput implements IDriverInput {
 	}
 	
 	public boolean turboArm() {
-		System.out.println("Turbo enabled!");
 		return gamepad.getButton(GamepadButton.B);
 	}
 }

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/gamepad/TankInput.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/gamepad/TankInput.java
@@ -42,4 +42,9 @@ public class TankInput implements IDriverInput {
 			return ControlSide.Current;
 		}
 	}
+	
+	public boolean turboArm() {
+		System.out.println("Turbo enabled!");
+		return gamepad.getButton(GamepadButton.B);
+	}
 }

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/GearShifter.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/GearShifter.java
@@ -11,9 +11,9 @@ public class GearShifter extends GearShiftStateManager {
 	protected void shiftGear(GearStates newState, IRobot robot) {
 		currentGear = newState;
 		if (newState == GearStates.High) {
-			robot.setGear(SolenoidValue.Forward);
-		} else if (newState == GearStates.Low) {
 			robot.setGear(SolenoidValue.Reverse);
+		} else if (newState == GearStates.Low) {
+			robot.setGear(SolenoidValue.Forward);
 		} 
 	}
 	

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -132,9 +132,15 @@ public class Robot extends IterativeRobot implements IRobot {
 		armMotor.ConfigFwdLimitSwitchNormallyOpen(true);
 		armMotor.ConfigRevLimitSwitchNormallyOpen(true);
 		armMotor.enableLimitSwitch(true, true);
+		armFollower.ConfigFwdLimitSwitchNormallyOpen(true);
+		armFollower.ConfigRevLimitSwitchNormallyOpen(true);
+		armFollower.enableLimitSwitch(true, true);
 		armExtendMotor.ConfigFwdLimitSwitchNormallyOpen(true);
 		armExtendMotor.ConfigRevLimitSwitchNormallyOpen(true);
 		armExtendMotor.enableLimitSwitch(true, true);
+		armExtendFollower.ConfigFwdLimitSwitchNormallyOpen(true);
+		armExtendFollower.ConfigRevLimitSwitchNormallyOpen(true);
+		armExtendFollower.enableLimitSwitch(true, true);
 		// leftFollower.changeControlMode(TalonControlMode.Follower);
 		// leftFollower.set(LEFT_INDEX);
 		

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -79,9 +79,10 @@ public class Robot extends IterativeRobot implements IRobot {
 	
 	double robotSpeed = 1;
 	double intakeSpeed = 1;
-	double armUpSpeed = 0.50;
-	double armDownSpeed = 0.25;
+	double armUpSpeed = 0.4;
+	double armDownSpeed = 0.23;
 	double armExtendSpeed = 1;
+	double turboSpeed = 1;
 	double upperGearThreshold = 0.6;
 	double lowerGearThreshold = 0.4;
 	
@@ -125,6 +126,8 @@ public class Robot extends IterativeRobot implements IRobot {
 		// rightFollower.set(RIGHT_INDEX);
 		leftFollower.setInverted(true);
 		leftMotor.setInverted(true);
+//		armExtendMotor.setInverted(false);
+//		armExtendMotor.setInverted(false); //NO changes
 		armMotor.enableBrakeMode(true);
 		armFollower.enableBrakeMode(true);
 		armExtendMotor.enableBrakeMode(true);
@@ -195,8 +198,7 @@ public class Robot extends IterativeRobot implements IRobot {
 			autoDriveDistance = SmartDashboard.getNumber("Distance");
 			lidarMotorSpeed = SmartDashboard.getNumber("Initial Lidar Speed");
 			autoController = new AutoController(
-			        new ArmAutonomous(1000, ArmAutonomous.LiftDirection.Down)
-					.addNext(new ForwardAutonomous(600, -0.5))
+					new ForwardAutonomous(600, -0.5)
 					.addNext(new RotateAutonomous(320, -1, RotateAutonomous.TurnDirection.Left))
 					.addNext(new ForwardAutonomous(4100, -0.5))
 					.addNext(new RotateAutonomous(750, -1, RotateAutonomous.TurnDirection.Right))
@@ -315,16 +317,25 @@ public class Robot extends IterativeRobot implements IRobot {
 		rightMotor.set(speed * robotSpeed);
 		rightFollower.set(speed * robotSpeed);
 	}
-	
 	@Override
-	public void setArmSpeed(double speed) {
-		if (speed > 0) {
+	public void setArmSpeed(double speed, boolean turbo) {
+		if (speed < 0) {
 			armMotor.set(speed * armUpSpeed);
 			armFollower.set(speed * armUpSpeed);
 		} else {
+			if (turbo) {
+				armMotor.set(speed * turboSpeed);
+				armFollower.set(speed * turboSpeed);
+			} else {
 			armMotor.set(speed * armDownSpeed);
 			armFollower.set(speed * armDownSpeed);
 		}
+	}
+	}
+
+	@Override
+	public void setArmSpeed(double speed) {
+		setArmSpeed(speed, false);
 	}
 	
 	@Override

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -51,8 +51,8 @@ public class Robot extends IterativeRobot implements IRobot {
 	static final int RIGHT_FOLLOWER_INDEX = 2;
 	static final int INTAKE_INDEX = 5;
 	// None of the below indexes are correct.
-	static final int ARM_EXTEND_INDEX = 6;
-	static final int ARM_EXTEND_FOLLOWER_INDEX = 9;
+	static final int ARM_EXTEND_INDEX = 9;
+	static final int ARM_EXTEND_FOLLOWER_INDEX = 6;
 	static final int ARM_INDEX = 7;
 	static final int ARM_FOLLOWER_INDEX = 8;
 	double MOTOR_POWER_FACTOR = 0.9;
@@ -142,6 +142,9 @@ public class Robot extends IterativeRobot implements IRobot {
 		armExtendFollower.ConfigFwdLimitSwitchNormallyOpen(true);
 		armExtendFollower.ConfigRevLimitSwitchNormallyOpen(true);
 		armExtendFollower.enableLimitSwitch(true, true);
+		
+		armExtendFollower.changeControlMode(CANTalon.TalonControlMode.Follower);
+		armExtendFollower.set(ARM_EXTEND_INDEX);
 //		System.out.println("Enabled all limit switches");
 		// leftFollower.changeControlMode(TalonControlMode.Follower);
 		// leftFollower.set(LEFT_INDEX);

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -130,26 +130,27 @@ public class Robot extends IterativeRobot implements IRobot {
 		armExtendFollower.enableBrakeMode(true);
 
 		
-		armMotor.ConfigFwdLimitSwitchNormallyOpen(true);
-		armMotor.ConfigRevLimitSwitchNormallyOpen(true);
-		armMotor.enableLimitSwitch(true, true);
-		armFollower.ConfigFwdLimitSwitchNormallyOpen(true);
-		armFollower.ConfigRevLimitSwitchNormallyOpen(true);
-		armFollower.enableLimitSwitch(true, true);
+//		armMotor.ConfigFwdLimitSwitchNormallyOpen(true);
+//		armMotor.ConfigRevLimitSwitchNormallyOpen(true);
+//		armMotor.enableLimitSwitch(true, true);
+//		armFollower.ConfigFwdLimitSwitchNormallyOpen(true);
+//		armFollower.ConfigRevLimitSwitchNormallyOpen(true);
+//		armFollower.enableLimitSwitch(true, true);
 		armExtendMotor.ConfigFwdLimitSwitchNormallyOpen(true);
 		armExtendMotor.ConfigRevLimitSwitchNormallyOpen(true);
 		armExtendMotor.enableLimitSwitch(true, true);
 		armExtendFollower.ConfigFwdLimitSwitchNormallyOpen(true);
 		armExtendFollower.ConfigRevLimitSwitchNormallyOpen(true);
 		armExtendFollower.enableLimitSwitch(true, true);
+//		System.out.println("Enabled all limit switches");
 		// leftFollower.changeControlMode(TalonControlMode.Follower);
 		// leftFollower.set(LEFT_INDEX);
 		
 		compressor.setClosedLoopControl(true);
 		setIntakeElevation(IntakeRaiseState.Raised);
-		gearShifter.shiftLow(this);
 		
 		IGamepad driverGamepad = new Gamepad(0);
+		gearShifter.shiftLow(this);
 		IGamepad operatorGamepad = new Gamepad(1);
 		IDriverInput tank = new TankInput(driverGamepad);
 		IDriverInput arcade = new ArcadeInput(driverGamepad);
@@ -177,8 +178,8 @@ public class Robot extends IterativeRobot implements IRobot {
     public void autonomousInit() {
 	    // Setting the limit switch to be normally closed
 	    // ensures that the motors will disable if the limit switches break.
-	    armMotor.ConfigFwdLimitSwitchNormallyOpen(false);
-	    armFollower.ConfigFwdLimitSwitchNormallyOpen(false);
+//	    armMotor.ConfigFwdLimitSwitchNormallyOpen(false);
+//	    armFollower.ConfigFwdLimitSwitchNormallyOpen(false);
 
 		sensorData.sendAttackColor("tegra-ubuntu:5888", SmartDashboard.getString("Enemy Color"));
 		
@@ -236,8 +237,8 @@ public class Robot extends IterativeRobot implements IRobot {
         // Setting the limit switches to be normally open
         // ensures the motor always works even when the limit switch
         // does not work. Note that this will cause a brief disabling of the arm.
-        armMotor.ConfigFwdLimitSwitchNormallyOpen(true);
-        armFollower.ConfigFwdLimitSwitchNormallyOpen(true);
+//        armMotor.ConfigFwdLimitSwitchNormallyOpen(true);
+//        armFollower.ConfigFwdLimitSwitchNormallyOpen(true);
 
     	lidarMotorSpeed = SmartDashboard.getNumber("Initial Lidar Speed");
     	

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -17,6 +17,7 @@ import org.usfirst.frc.team1076.robot.gamepad.OperatorInput;
 import org.usfirst.frc.team1076.robot.gamepad.TankInput;
 import org.usfirst.frc.team1076.robot.sensors.DistanceEncoder;
 import org.usfirst.frc.team1076.robot.sensors.IDistanceEncoder;
+import org.usfirst.frc.team1076.robot.statemachine.ArmAutonomous;
 import org.usfirst.frc.team1076.robot.statemachine.AutoState;
 import org.usfirst.frc.team1076.robot.statemachine.ForwardAutonomous;
 import org.usfirst.frc.team1076.robot.statemachine.IntakeAutonomous;
@@ -170,7 +171,8 @@ public class Robot extends IterativeRobot implements IRobot {
 			autoDriveDistance = SmartDashboard.getNumber("Distance");
 			lidarMotorSpeed = SmartDashboard.getNumber("Initial Lidar Speed");
 			autoController = new AutoController(
-					new ForwardAutonomous(600, -0.5)
+			        new ArmAutonomous(1000, ArmAutonomous.LiftDirection.Down)
+					.addNext(new ForwardAutonomous(600, -0.5))
 					.addNext(new RotateAutonomous(320, -1, RotateAutonomous.TurnDirection.Left))
 					.addNext(new ForwardAutonomous(4100, -0.5))
 					.addNext(new RotateAutonomous(750, -1, RotateAutonomous.TurnDirection.Right))

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -162,7 +162,7 @@ public class Robot extends IterativeRobot implements IRobot {
 		IDriverInput tank = new TankInput(driverGamepad);
 		IDriverInput arcade = new ArcadeInput(driverGamepad);
 		IOperatorInput operator = new OperatorInput(operatorGamepad);
-		teleopController = new TeleopController(arcade, operator, tank, arcade);
+		teleopController = new TeleopController(tank, operator, tank, arcade);
 		encoder = new DistanceEncoder(new MotorEncoder(leftMotor), gearShifter);
 		autoController = new AutoController(new NothingAutonomous());
 		testController = new TestController(driverGamepad);

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -154,7 +154,7 @@ public class Robot extends IterativeRobot implements IRobot {
 		// leftFollower.set(LEFT_INDEX);
 		
 		compressor.setClosedLoopControl(true);
-		setIntakeElevation(IntakeRaiseState.Raised);
+		setIntakeElevation(IntakeRaiseState.Lowered); //TODO: the lable for lowered and raised is swaped incorrectly!
 		
 		IGamepad driverGamepad = new Gamepad(0);
 		gearShifter.shiftLow(this);

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -127,6 +127,7 @@ public class Robot extends IterativeRobot implements IRobot {
 		armFollower.enableBrakeMode(true);
 		armExtendMotor.enableBrakeMode(true);
 		armExtendFollower.enableBrakeMode(true);
+
 		
 		armMotor.ConfigFwdLimitSwitchNormallyOpen(true);
 		armMotor.ConfigRevLimitSwitchNormallyOpen(true);
@@ -167,6 +168,11 @@ public class Robot extends IterativeRobot implements IRobot {
 	 */
 	@Override
     public void autonomousInit() {
+	    // Setting the limit switch to be normally closed
+	    // ensures that the motors will disable if the limit switches break.
+	    armMotor.ConfigFwdLimitSwitchNormallyOpen(false);
+	    armFollower.ConfigFwdLimitSwitchNormallyOpen(false);
+
 		sensorData.sendAttackColor("tegra-ubuntu:5888", SmartDashboard.getString("Enemy Color"));
 		
 		if (SmartDashboard.getBoolean("Auto Program Enabled")) {
@@ -219,6 +225,12 @@ public class Robot extends IterativeRobot implements IRobot {
 
     @Override
     public void teleopInit() {
+        // Setting the limit switches to be normally open
+        // ensures the motor always works even when the limit switch
+        // does not work. Note that this will cause a brief disabling of the arm.
+        armMotor.ConfigFwdLimitSwitchNormallyOpen(true);
+        armFollower.ConfigFwdLimitSwitchNormallyOpen(true);
+
     	lidarMotorSpeed = SmartDashboard.getNumber("Initial Lidar Speed");
     	
     	if (teleopController != null) {

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -115,11 +115,11 @@ public class Robot extends IterativeRobot implements IRobot {
 		SmartDashboard.putNumber("Distance", autoDriveDistance);
 		SmartDashboard.putNumber("Initial Lidar Speed", initialLidarSpeed);
     	SmartDashboard.putBoolean("Auto Program Enabled", false);
-    	SmartDashboard.putString("Auto Program", "elevate up ; forward 3.9 0.65 ; elevate down ;"
-    			+ "forward 0.6 0.5 ; rotate left 0.3 ; forward 3.5 ; rotate right 0.59 ;"
-    			+ "vision 2.5 0.45 ; intake 1 out ; intake 0.5 in ; rotate right 0.05 ;"
-    			+ "intake 1 out ; intake 0.5 in ; rotate right 0.05 ; intake 1 out");
-
+    	//SmartDashboard.putString("Auto Program", "elevate up ; forward 3.9 0.65 ; elevate down ;"
+    	//		+ "forward 0.6 0.5 ; rotate left 0.3 ; forward 3.5 ; rotate right 0.59 ;"
+    	//		+ "vision 2.5 0.45 ; intake 1 out ; intake 0.5 in ; rotate right 0.05 ;"
+    	//		+ "intake 1 out ; intake 0.5 in ; rotate right 0.05 ; intake 1 out");
+    	SmartDashboard.putString("Auto Program", "nothing");
 		// Initialize the physical components before the controllers,
 		// in case they depend on them.
 		// rightFollower.changeControlMode(TalonControlMode.Follower);
@@ -190,27 +190,28 @@ public class Robot extends IterativeRobot implements IRobot {
 
 		sensorData.sendAttackColor("tegra-ubuntu:5888", SmartDashboard.getString("Enemy Color"));
 		
-		if (SmartDashboard.getBoolean("Auto Program Enabled")) {
+		if (false && SmartDashboard.getBoolean("Auto Program Enabled")) {
 			String source = SmartDashboard.getString("Auto Program");
 			AutoState program = StateMachineCompiler.compile(source, sensorData);
 			autoController = new AutoController(program);
 		} else {
 			autoDriveDistance = SmartDashboard.getNumber("Distance");
 			lidarMotorSpeed = SmartDashboard.getNumber("Initial Lidar Speed");
-			autoController = new AutoController(
-					new ForwardAutonomous(600, -0.5)
-					.addNext(new RotateAutonomous(320, -1, RotateAutonomous.TurnDirection.Left))
-					.addNext(new ForwardAutonomous(4100, -0.5))
-					.addNext(new RotateAutonomous(750, -1, RotateAutonomous.TurnDirection.Right))
-					.addNext(new VisionAutonomous(1500, -0.7, sensorData))
-					.addNext(new IntakeAutonomous(1500, -1))
-					.addNext(new IntakeAutonomous(1000, 1))
-					.addNext(new IntakeAutonomous(1500, -1)));
+			autoController = new AutoController(new ForwardAutonomous(7000, 0.75)); //TODO: investigate forwards backwards stuff.
+//			autoController = new AutoController
+//					new ForwardAutonomous(600, -0.5)
+//					.addNext(new RotateAutonomous(320, -1, RotateAutonomous.TurnDirection.Left))
+//					.addNext(new ForwardAutonomous(4100, -0.5))
+//					.addNext(new RotateAutonomous(750, -1, RotateAutonomous.TurnDirection.Right))
+//					.addNext(new VisionAutonomous(1500, -0.7, sensorData))
+//					.addNext(new IntakeAutonomous(1500, -1))
+//					.addNext(new IntakeAutonomous(1000, 1))
+//					.addNext(new IntakeAutonomous(1500, -1)));
 		}
 		/*
 		if (SmartDashboard.getBoolean("Low Bar")) {
 			autoController = new AutoController(new IntakeElevationAutonomous(IntakeRaiseState.Lowered)
-					.addNext(new ForwardAutonomous(6000, -0.6)));
+					.addNext(new ForwardA`utonomous(6000, -0.6)));
 		} else if (SmartDashboard.getBoolean("Backwards")) {
 			autoController = new AutoController(new ForwardAutonomous(6000, 0.6));
 		}

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -127,6 +127,13 @@ public class Robot extends IterativeRobot implements IRobot {
 		armFollower.enableBrakeMode(true);
 		armExtendMotor.enableBrakeMode(true);
 		armExtendFollower.enableBrakeMode(true);
+		
+		armMotor.ConfigFwdLimitSwitchNormallyOpen(true);
+		armMotor.ConfigRevLimitSwitchNormallyOpen(true);
+		armMotor.enableLimitSwitch(true, true);
+		armExtendMotor.ConfigFwdLimitSwitchNormallyOpen(true);
+		armExtendMotor.ConfigRevLimitSwitchNormallyOpen(true);
+		armExtendMotor.enableLimitSwitch(true, true);
 		// leftFollower.changeControlMode(TalonControlMode.Follower);
 		// leftFollower.set(LEFT_INDEX);
 		

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -80,11 +80,11 @@ public class Robot extends IterativeRobot implements IRobot {
 	
 	double robotSpeed = 1;
 	double intakeSpeed = 1;
-	double armUpSpeed = 0.4;
-	double armDownSpeed = 0.23;
+//	double armUpSpeed = 0.4;
+//	double armDownSpeed = 0.23;
 	double armExtendSpeed = 1;
-	double driverTurboSpeed = 1;
-	double operatorTurboSpeed = 0.75;
+//	double driverTurboSpeed = 1;
+//	double operatorTurboSpeed = 0.75;
 	double upperGearThreshold = 0.6;
 	double lowerGearThreshold = 0.4;
 	
@@ -325,44 +325,9 @@ public class Robot extends IterativeRobot implements IRobot {
 	}
 
 	@Override
-	public void setArmSpeed(double speed, boolean turbo, boolean operatorTurbo) {
-	    /**
-	     Turbo mode increases the power going to the lift arm. This allows
-	     the arm to recover from moving too far forwards. The driver has a full
-	     power turbo while the operator has a 75% turbo. The driver takes precedence.
-	     The turbo mode only applies when lowering the lift arm.
-
-	     Note that the raising and lowering of the arm differ in speed even
-	     when not in any turbo mode. Lowering is less powerful due to gravity
-	     helping. This difference can not be turned off.
-	     */
-		if (speed > 0) {
-			armMotor.set(speed * armUpSpeed);
-			armFollower.set(speed * armUpSpeed);
-		} else {
-			if (turbo) {
-				armMotor.set(speed * driverTurboSpeed);
-				armFollower.set(speed * driverTurboSpeed);
-			} else if (operatorTurbo) {
-				armMotor.set(speed * operatorTurboSpeed);
-				armFollower.set(speed * operatorTurboSpeed);
-			} else {
-			    armMotor.set(speed * armDownSpeed);
-			    armFollower.set(speed * armDownSpeed);
-			}
-		}
-	}
-
-	// Driver turbo mode.
-	@Override
-	public void setArmSpeed(double speed, boolean turbo) {
-		setArmSpeed(speed, turbo, false);
-	}
-
-	// Standard lift arm speed.
-	@Override
 	public void setArmSpeed(double speed) {
-		setArmSpeed(speed, false);
+		armMotor.set(speed);
+		armFollower.set(speed);
 	}
 
 	@Override
@@ -445,24 +410,4 @@ public class Robot extends IterativeRobot implements IRobot {
 	    }
 	    setLidarSpeed(lidarMotorSpeed);
 	}
-	
-	@Override
-	public double getArmDownSpeed() {
-	    return armDownSpeed;
-	}
-
-    @Override
-    public double getArmUpSpeed() {
-        return armUpSpeed;
-    }
-
-    @Override
-    public double getArmTurboSpeed() {
-        return driverTurboSpeed;
-    }
-
-    @Override
-    public double getArmOperatorTurboSpeed() {
-        return operatorTurboSpeed;
-    }
 }

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -79,7 +79,8 @@ public class Robot extends IterativeRobot implements IRobot {
 	
 	double robotSpeed = 1;
 	double intakeSpeed = 1;
-	double armSpeed = 0.5;
+	double armUpSpeed = 0.50;
+	double armDownSpeed = 0.25;
 	double armExtendSpeed = 1;
 	double upperGearThreshold = 0.6;
 	double lowerGearThreshold = 0.4;
@@ -317,8 +318,13 @@ public class Robot extends IterativeRobot implements IRobot {
 	
 	@Override
 	public void setArmSpeed(double speed) {
-		armMotor.set(speed * armSpeed);
-		armFollower.set(speed * armSpeed);
+		if (speed > 0) {
+			armMotor.set(speed * armUpSpeed);
+			armFollower.set(speed * armUpSpeed);
+		} else {
+			armMotor.set(speed * armDownSpeed);
+			armFollower.set(speed * armDownSpeed);
+		}
 	}
 	
 	@Override

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -323,11 +323,20 @@ public class Robot extends IterativeRobot implements IRobot {
 		rightMotor.set(speed * robotSpeed);
 		rightFollower.set(speed * robotSpeed);
 	}
+
 	@Override
 	public void setArmSpeed(double speed, boolean turbo, boolean operatorTurbo) {
-		//TODO: 50% speed on arm if operator b button pressed.
-		//Driver precednece
-		if (speed < 0) {
+	    /**
+	     Turbo mode increases the power going to the lift arm. This allows
+	     the arm to recover from moving too far forwards. The driver has a full
+	     power turbo while the operator has a 75% turbo. The driver takes precedence.
+	     The turbo mode only applies when lowering the lift arm.
+
+	     Note that the raising and lowering of the arm differ in speed even
+	     when not in any turbo mode. Lowering is less powerful due to gravity
+	     helping. This difference can not be turned off.
+	     */
+		if (speed > 0) {
 			armMotor.set(speed * armUpSpeed);
 			armFollower.set(speed * armUpSpeed);
 		} else {
@@ -338,22 +347,24 @@ public class Robot extends IterativeRobot implements IRobot {
 				armMotor.set(speed * operatorTurboSpeed);
 				armFollower.set(speed * operatorTurboSpeed);
 			} else {
-			armMotor.set(speed * armDownSpeed);
-			armFollower.set(speed * armDownSpeed);
+			    armMotor.set(speed * armDownSpeed);
+			    armFollower.set(speed * armDownSpeed);
 			}
 		}
 	}
-	
+
+	// Driver turbo mode.
 	@Override
 	public void setArmSpeed(double speed, boolean turbo) {
 		setArmSpeed(speed, turbo, false);
 	}
 
+	// Standard lift arm speed.
 	@Override
 	public void setArmSpeed(double speed) {
 		setArmSpeed(speed, false);
 	}
-	
+
 	@Override
 	public void setArmExtendSpeed(double speed) {
 		armExtendMotor.set(speed * armExtendSpeed);
@@ -434,4 +445,24 @@ public class Robot extends IterativeRobot implements IRobot {
 	    }
 	    setLidarSpeed(lidarMotorSpeed);
 	}
+	
+	@Override
+	public double getArmDownSpeed() {
+	    return armDownSpeed;
+	}
+
+    @Override
+    public double getArmUpSpeed() {
+        return armUpSpeed;
+    }
+
+    @Override
+    public double getArmTurboSpeed() {
+        return driverTurboSpeed;
+    }
+
+    @Override
+    public double getArmOperatorTurboSpeed() {
+        return operatorTurboSpeed;
+    }
 }

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/physical/Robot.java
@@ -18,6 +18,7 @@ import org.usfirst.frc.team1076.robot.gamepad.TankInput;
 import org.usfirst.frc.team1076.robot.sensors.DistanceEncoder;
 import org.usfirst.frc.team1076.robot.sensors.IDistanceEncoder;
 import org.usfirst.frc.team1076.robot.statemachine.ArmAutonomous;
+import org.usfirst.frc.team1076.robot.statemachine.ArmAutonomous.LiftDirection;
 import org.usfirst.frc.team1076.robot.statemachine.AutoState;
 import org.usfirst.frc.team1076.robot.statemachine.ForwardAutonomous;
 import org.usfirst.frc.team1076.robot.statemachine.IntakeAutonomous;
@@ -82,7 +83,8 @@ public class Robot extends IterativeRobot implements IRobot {
 	double armUpSpeed = 0.4;
 	double armDownSpeed = 0.23;
 	double armExtendSpeed = 1;
-	double turboSpeed = 1;
+	double driverTurboSpeed = 1;
+	double operatorTurboSpeed = 0.75;
 	double upperGearThreshold = 0.6;
 	double lowerGearThreshold = 0.4;
 	
@@ -197,7 +199,10 @@ public class Robot extends IterativeRobot implements IRobot {
 		} else {
 			autoDriveDistance = SmartDashboard.getNumber("Distance");
 			lidarMotorSpeed = SmartDashboard.getNumber("Initial Lidar Speed");
-			autoController = new AutoController(new ForwardAutonomous(7000, 0.75)); //TODO: investigate forwards backwards stuff.
+			
+			autoController = new AutoController(new ForwardAutonomous(7000, 0.75)
+												.addNext(new ArmAutonomous(100, 0.5, LiftDirection.Down))); 
+												//TODO: investigate forwards backwards stuff.
 //			autoController = new AutoController
 //					new ForwardAutonomous(600, -0.5)
 //					.addNext(new RotateAutonomous(320, -1, RotateAutonomous.TurnDirection.Left))
@@ -211,7 +216,7 @@ public class Robot extends IterativeRobot implements IRobot {
 		/*
 		if (SmartDashboard.getBoolean("Low Bar")) {
 			autoController = new AutoController(new IntakeElevationAutonomous(IntakeRaiseState.Lowered)
-					.addNext(new ForwardA`utonomous(6000, -0.6)));
+					.addNext(new ForwardAutonomous(6000, -0.6)));
 		} else if (SmartDashboard.getBoolean("Backwards")) {
 			autoController = new AutoController(new ForwardAutonomous(6000, 0.6));
 		}
@@ -319,19 +324,29 @@ public class Robot extends IterativeRobot implements IRobot {
 		rightFollower.set(speed * robotSpeed);
 	}
 	@Override
-	public void setArmSpeed(double speed, boolean turbo) {
+	public void setArmSpeed(double speed, boolean turbo, boolean operatorTurbo) {
+		//TODO: 50% speed on arm if operator b button pressed.
+		//Driver precednece
 		if (speed < 0) {
 			armMotor.set(speed * armUpSpeed);
 			armFollower.set(speed * armUpSpeed);
 		} else {
 			if (turbo) {
-				armMotor.set(speed * turboSpeed);
-				armFollower.set(speed * turboSpeed);
+				armMotor.set(speed * driverTurboSpeed);
+				armFollower.set(speed * driverTurboSpeed);
+			} else if (operatorTurbo) {
+				armMotor.set(speed * operatorTurboSpeed);
+				armFollower.set(speed * operatorTurboSpeed);
 			} else {
 			armMotor.set(speed * armDownSpeed);
 			armFollower.set(speed * armDownSpeed);
+			}
 		}
 	}
+	
+	@Override
+	public void setArmSpeed(double speed, boolean turbo) {
+		setArmSpeed(speed, turbo, false);
 	}
 
 	@Override

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/ArmAutonomous.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/ArmAutonomous.java
@@ -3,8 +3,6 @@ package org.usfirst.frc.team1076.robot.statemachine;
 import java.util.concurrent.TimeUnit;
 
 public class ArmAutonomous extends AutoState {
-	// MAJOR TODO: Use Encoders or Limit Switches
-	//(once they're put on the robot)
 	public enum LiftDirection {
 		Up, Down
 	};
@@ -38,17 +36,16 @@ public class ArmAutonomous extends AutoState {
 
 	@Override
 	public double armSpeed() {
-		if (shouldChange()) {
-			return 0;
-		} else {
-			switch (liftDirection) {
-			case Up:
-				return speed;
-			case Down:
-				return -speed;
-			default:
-				return 0;
-			}
-		}
+	    if (shouldChange()) {
+	        return 0;
+	    }
+	    switch (liftDirection) {
+	    case Up:
+	        return speed;
+	    case Down:
+	        return -speed;
+	    default:
+	        return 0;
+	    }
 	}
 }

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/ArmAutonomous.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/ArmAutonomous.java
@@ -1,0 +1,54 @@
+package org.usfirst.frc.team1076.robot.statemachine;
+
+import java.util.concurrent.TimeUnit;
+
+public class ArmAutonomous extends AutoState {
+	// MAJOR TODO: Use Encoders or Limit Switches
+	//(once they're put on the robot)
+	public enum LiftDirection {
+		Up, Down
+	};
+
+	LiftDirection liftDirection;
+	long timeStart;
+	long timeLimit;
+	boolean started = false;
+	double speed;
+
+	public ArmAutonomous(int millis, double speed, LiftDirection liftDirection) {
+		this.speed = speed;
+		this.timeLimit = millis;
+		this.liftDirection = liftDirection;
+	}
+
+	public ArmAutonomous(int millis, LiftDirection liftDirection) {
+		this(millis, 1, liftDirection);
+	}
+
+	@Override
+	public void init() {
+		started = true;
+		timeStart = System.nanoTime();
+	}
+
+	@Override
+	public boolean shouldChange() {
+		return started && TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - timeStart) > timeLimit;
+	}
+
+	@Override
+	public double armSpeed() {
+		if (shouldChange()) {
+			return 0;
+		} else {
+			switch (liftDirection) {
+			case Up:
+				return speed;
+			case Down:
+				return -speed;
+			default:
+				return 0;
+			}
+		}
+	}
+}

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/ArmExtendAutonomous.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/ArmExtendAutonomous.java
@@ -38,15 +38,14 @@ public class ArmExtendAutonomous extends AutoState {
 	public double armExtendSpeed() {
 		if (shouldChange()) {
 			return 0;
-		} else {
-			switch (extendDirection) {
-			case Forwards:
-				return speed;
-			case Backwards:
-				return -speed;
-			default:
-				return 0;
-			}
+		}
+		switch (extendDirection) {
+		case Forwards:
+		    return speed;
+		case Backwards:
+		    return -speed;
+		default:
+		    return 0;
 		}
 	}
 }

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/ArmExtendAutonomous.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/ArmExtendAutonomous.java
@@ -1,0 +1,52 @@
+package org.usfirst.frc.team1076.robot.statemachine;
+
+import java.util.concurrent.TimeUnit;
+
+public class ArmExtendAutonomous extends AutoState {
+	public enum ExtendDirection {
+		Forwards, Backwards
+	};
+
+	ExtendDirection extendDirection;
+	long timeStart;
+	long timeLimit;
+	boolean started = false;
+	double speed;
+
+	public ArmExtendAutonomous(int millis, double speed, ExtendDirection extendDirection) {
+		this.speed = speed;
+		this.timeLimit = millis;
+		this.extendDirection = extendDirection;
+	}
+
+	public ArmExtendAutonomous(int millis, ExtendDirection extendDirection) {
+		this(millis, 1, extendDirection);
+	}
+
+	@Override
+	public void init() {
+		started = true;
+		timeStart = System.nanoTime();
+	}
+
+	@Override
+	public boolean shouldChange() {
+		return started && TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - timeStart) > timeLimit;
+	}
+
+	@Override
+	public double armExtendSpeed() {
+		if (shouldChange()) {
+			return 0;
+		} else {
+			switch (extendDirection) {
+			case Forwards:
+				return speed;
+			case Backwards:
+				return -speed;
+			default:
+				return 0;
+			}
+		}
+	}
+}

--- a/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/AutoState.java
+++ b/FRC1076-2016-Competition/src/org/usfirst/frc/team1076/robot/statemachine/AutoState.java
@@ -35,7 +35,11 @@ public abstract class AutoState {
 	public double armSpeed() {
 		return 0;
 	}
-	
+
+	public double armExtendSpeed() {
+		return 0;
+	}
+
 	public double intakeSpeed() {
 		return 0;
 	}

--- a/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/ArmAutonomousTest.java
+++ b/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/ArmAutonomousTest.java
@@ -7,10 +7,8 @@ import org.usfirst.frc.team1076.robot.gamepad.IDriverInput.MotorOutput;
 import org.usfirst.frc.team1076.robot.statemachine.ArmAutonomous;
 import org.usfirst.frc.team1076.robot.statemachine.ArmAutonomous.LiftDirection;
 import org.usfirst.frc.team1076.robot.statemachine.AutoState;
-import org.usfirst.frc.team1076.test.mock.MockRobot;
 
 public class ArmAutonomousTest {
-	MockRobot robot = new MockRobot();
 	private static final double EPSILON = 1e-12;
 
 	@Test

--- a/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/ArmAutonomousTest.java
+++ b/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/ArmAutonomousTest.java
@@ -1,0 +1,47 @@
+package org.usfirst.frc.team1076.test.controller;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.usfirst.frc.team1076.robot.gamepad.IDriverInput.MotorOutput;
+import org.usfirst.frc.team1076.robot.statemachine.ArmAutonomous;
+import org.usfirst.frc.team1076.robot.statemachine.ArmAutonomous.LiftDirection;
+import org.usfirst.frc.team1076.robot.statemachine.AutoState;
+import org.usfirst.frc.team1076.test.mock.MockRobot;
+
+public class ArmAutonomousTest {
+	MockRobot robot = new MockRobot();
+	private static final double EPSILON = 1e-12;
+
+	@Test
+	public void testArmRaising() {
+		AutoState auto = new ArmAutonomous(100, 1.0, LiftDirection.Up);
+		auto.init();
+
+		assertFalse("ArmAutonomous should not change before doing work!", auto.shouldChange());
+		assertEquals(1.0, auto.armSpeed(), EPSILON);
+
+		try {
+			Thread.sleep(100);
+		} catch (InterruptedException e) {
+		}
+
+		assertTrue("ArmAutonomous should change after doing work!", auto.shouldChange());
+		assertEquals(0.0, auto.armSpeed(), EPSILON);
+	}
+
+	public void testArmLowering() {
+		AutoState auto = new ArmAutonomous(100, 1.0, LiftDirection.Down);
+		auto.init();
+
+		assertEquals(-1.0, auto.armSpeed(), EPSILON);
+	}
+
+	@Test
+	public void testNoDriveTrainMotion() {
+		AutoState auto = new ArmAutonomous(1, 1.0, LiftDirection.Up);
+		MotorOutput motorOutput = auto.driveTrainSpeed();
+		assertEquals(0.0, motorOutput.left, EPSILON);
+		assertEquals(0.0, motorOutput.right, EPSILON);
+	}
+}

--- a/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/ArmExtendAutonomousTest.java
+++ b/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/ArmExtendAutonomousTest.java
@@ -1,0 +1,47 @@
+package org.usfirst.frc.team1076.test.controller;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.usfirst.frc.team1076.robot.gamepad.IDriverInput.MotorOutput;
+import org.usfirst.frc.team1076.robot.statemachine.ArmExtendAutonomous;
+import org.usfirst.frc.team1076.robot.statemachine.AutoState;
+import org.usfirst.frc.team1076.robot.statemachine.ArmExtendAutonomous.ExtendDirection;
+
+public class ArmExtendAutonomousTest {
+	private static final double EPSILON = 1e-12;
+
+	@Test
+	public void testArmExtending() {
+		ArmExtendAutonomous auto = new ArmExtendAutonomous(50, 1.0, ExtendDirection.Forwards);
+		auto.init();
+
+		assertFalse("ArmExtendAutonomous should not change before doing work!", auto.shouldChange());
+		assertEquals(1.0, auto.armExtendSpeed(), EPSILON);
+
+		try {
+			Thread.sleep(200);
+		} catch (InterruptedException e) {
+		}
+
+		assertEquals(0.0, auto.armExtendSpeed(), EPSILON);
+		assertTrue("ArmExtendAutonomous should change after doing work!", auto.shouldChange());
+	}
+
+	public void testArmRetracting() {
+		AutoState auto = new ArmExtendAutonomous(100, 1.0, ExtendDirection.Backwards);
+		auto.init();
+
+		assertEquals(-1.0, auto.armExtendSpeed(), EPSILON);
+	}
+
+	@Test
+	public void testNoDriveTrainMotion() {
+		AutoState auto = new ArmExtendAutonomous(1, 1.0, ExtendDirection.Forwards);
+		MotorOutput motorOutput = auto.driveTrainSpeed();
+		assertEquals(0.0, motorOutput.left, EPSILON);
+		assertEquals(0.0, motorOutput.right, EPSILON);
+	}
+}

--- a/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/TeleopControllerTest.java
+++ b/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/TeleopControllerTest.java
@@ -39,16 +39,66 @@ public class TeleopControllerTest {
 	}
 	
 	@Test
-	public void testArmMotion() {
-		for (int i = -100; i <= 100; i++) {
-			double value = i / 100.0;
-			operatorInput.arm = value;
-			controller.teleopPeriodic(robot);
-			assertEquals("The arm motion should match the arm input",
-					value, robot.arm, EPSILON);
-		}
+	public void testUpArmMotion() {
+	    for (int i = 0; i <= 100; i++) {
+	        robot.armUpSpeed = 0.5;
+	        double value = i / 100.0;
+	        operatorInput.arm = value;
+	        controller.teleopPeriodic(robot);
+	        double expected =  value * robot.armUpSpeed;
+	        assertEquals("The arm motion should be the arm input " +
+	                     "reduced by a factor of " + robot.armUpSpeed,
+	                     expected, robot.arm, EPSILON);
+	    }
 	}
 	
+	@Test
+	public void testDownArmMotion() {
+	    for (int i = -100; i <= 0; i++) {
+	        robot.armDownSpeed = 0.5;
+	        double value = i / 100.0;
+	        operatorInput.arm = value;
+	        controller.teleopPeriodic(robot);
+	        double expected =  value * robot.armDownSpeed;
+
+	        assertEquals("The arm motion should be the arm input "
+	                + "reduced by a factor of " + robot.armDownSpeed,
+	                expected, robot.arm, EPSILON);
+	    }
+	}
+
+	@Test
+	public void testDriverTurboArmMotion() {
+	    for (int i = -100; i <= 0; i++) {
+	        robot.driverTurboSpeed = 0.9;
+	        double value = i / 100.0;
+	        operatorInput.arm = value;
+	        driverInput.turboArm = true;
+	        controller.teleopPeriodic(robot);
+	        double expected =  value * robot.driverTurboSpeed;
+
+	        assertEquals("The arm motion should be the arm input "
+	                + "multiplied by a factor of " + robot.driverTurboSpeed,
+	                expected, robot.arm, EPSILON);
+	    }
+	}
+
+    @Test
+    public void testOperatorTurboArmMotion() {
+        for (int i = -100; i <= 0; i++) {
+            robot.operatorTurboSpeed = 0.75;
+            double value = i / 100.0;
+            operatorInput.arm = value;
+            operatorInput.operatorTurbo = true;
+            controller.teleopPeriodic(robot);
+            double expected =  value * robot.operatorTurboSpeed;
+
+            assertEquals("The arm motion should be the arm input "
+                    + "multiplied by a factor of " + robot.operatorTurboSpeed,
+                    expected, robot.arm, EPSILON);
+        }
+    }
+
 	@Test
 	public void testArmExtension() {
 		for (int i = -100; i <= 100; i++) {

--- a/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/TeleopControllerTest.java
+++ b/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/controller/TeleopControllerTest.java
@@ -41,13 +41,14 @@ public class TeleopControllerTest {
 	@Test
 	public void testUpArmMotion() {
 	    for (int i = 0; i <= 100; i++) {
-	        robot.armUpSpeed = 0.5;
+	        double armUpSpeed = controller.getArmUpSpeed();
 	        double value = i / 100.0;
+	        double expected =  value * armUpSpeed;
+
 	        operatorInput.arm = value;
 	        controller.teleopPeriodic(robot);
-	        double expected =  value * robot.armUpSpeed;
 	        assertEquals("The arm motion should be the arm input " +
-	                     "reduced by a factor of " + robot.armUpSpeed,
+	                     "reduced by a factor of " + armUpSpeed,
 	                     expected, robot.arm, EPSILON);
 	    }
 	}
@@ -55,14 +56,14 @@ public class TeleopControllerTest {
 	@Test
 	public void testDownArmMotion() {
 	    for (int i = -100; i <= 0; i++) {
-	        robot.armDownSpeed = 0.5;
+	        double armDownSpeed = controller.getArmDownSpeed();
 	        double value = i / 100.0;
+            double expected =  value * armDownSpeed;
+
 	        operatorInput.arm = value;
 	        controller.teleopPeriodic(robot);
-	        double expected =  value * robot.armDownSpeed;
-
 	        assertEquals("The arm motion should be the arm input "
-	                + "reduced by a factor of " + robot.armDownSpeed,
+	                + "reduced by a factor of " + armDownSpeed,
 	                expected, robot.arm, EPSILON);
 	    }
 	}
@@ -70,15 +71,15 @@ public class TeleopControllerTest {
 	@Test
 	public void testDriverTurboArmMotion() {
 	    for (int i = -100; i <= 0; i++) {
-	        robot.driverTurboSpeed = 0.9;
+	        double driverTurboSpeed = controller.getDriverTurboSpeed();
 	        double value = i / 100.0;
+            double expected =  value * driverTurboSpeed;
+
 	        operatorInput.arm = value;
 	        driverInput.turboArm = true;
 	        controller.teleopPeriodic(robot);
-	        double expected =  value * robot.driverTurboSpeed;
-
 	        assertEquals("The arm motion should be the arm input "
-	                + "multiplied by a factor of " + robot.driverTurboSpeed,
+	                + "multiplied by a factor of " + driverTurboSpeed,
 	                expected, robot.arm, EPSILON);
 	    }
 	}
@@ -86,15 +87,15 @@ public class TeleopControllerTest {
     @Test
     public void testOperatorTurboArmMotion() {
         for (int i = -100; i <= 0; i++) {
-            robot.operatorTurboSpeed = 0.75;
+            double operatorTurboSpeed = controller.getOperatorTurboSpeed();
             double value = i / 100.0;
+            double expected =  value * operatorTurboSpeed;
+
             operatorInput.arm = value;
             operatorInput.operatorTurbo = true;
             controller.teleopPeriodic(robot);
-            double expected =  value * robot.operatorTurboSpeed;
-
             assertEquals("The arm motion should be the arm input "
-                    + "multiplied by a factor of " + robot.operatorTurboSpeed,
+                    + "multiplied by a factor of " + operatorTurboSpeed,
                     expected, robot.arm, EPSILON);
         }
     }

--- a/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/mock/MockDriverInput.java
+++ b/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/mock/MockDriverInput.java
@@ -6,6 +6,7 @@ public class MockDriverInput implements IDriverInput {
 	public double left, right;
 	public boolean brakes;
 	public ControlSide controlSide = ControlSide.Current;
+	public boolean turboArm;
 	
 	public void reset() {
 		left = right = 0;
@@ -36,4 +37,9 @@ public class MockDriverInput implements IDriverInput {
 	public ControlSide controlSide() {
 		return controlSide;
 	}
+
+    @Override
+    public boolean turboArm() {
+        return turboArm;
+    }
 }

--- a/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/mock/MockOperatorInput.java
+++ b/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/mock/MockOperatorInput.java
@@ -5,6 +5,7 @@ import org.usfirst.frc.team1076.robot.gamepad.IOperatorInput;
 public class MockOperatorInput implements IOperatorInput {
 
 	public double arm, intake, extend;
+	public boolean operatorTurbo;
 	public IntakeRaiseState raiseState = IntakeRaiseState.Neutral;
 	
 	public void reset() {
@@ -31,4 +32,9 @@ public class MockOperatorInput implements IOperatorInput {
 	public IntakeRaiseState intakeRaiseState() {
 		return raiseState;
 	}
+
+    @Override
+    public boolean operatorTurbo() {
+        return operatorTurbo;
+    }
 }

--- a/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/mock/MockRobot.java
+++ b/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/mock/MockRobot.java
@@ -8,6 +8,7 @@ import org.usfirst.frc.team1076.udp.ISensorData;
 public class MockRobot implements IRobot {
 	public double left, right, arm, intake, extend;
 	public double lidarSpeed;
+	public double armDownSpeed, armUpSpeed, driverTurboSpeed, operatorTurboSpeed;
 	public boolean brakes;
 	public IntakeRaiseState intakeRaiseState = IntakeRaiseState.Neutral;
 	public SolenoidValue gear = SolenoidValue.Off;
@@ -67,17 +68,45 @@ public class MockRobot implements IRobot {
 	public void setArmExtendSpeed(double speed) {
 		this.extend = speed;
 	}
-	// Should the two below do anything?
+	
     @Override
     public void setArmSpeed(double speed, boolean turbo) {
-        // TODO Auto-generated method stub
-        
+        setArmSpeed(speed, turbo, false); 
     }
 
     @Override
     public void setArmSpeed(double speed, boolean turbo, boolean operatorTurbo) {
-        // TODO Auto-generated method stub
-        
+        if (speed > 0) {
+           this.arm  = speed * armUpSpeed;
+        } else {
+            if (turbo) {
+                this.arm = speed * driverTurboSpeed;
+            } else if (operatorTurbo) {
+                this.arm = speed * operatorTurboSpeed;
+            } else {
+                this.arm = speed * armDownSpeed;
+            }
+        }
+    }
+
+    @Override
+    public double getArmDownSpeed() {
+        return armDownSpeed;
+    }
+
+    @Override
+    public double getArmUpSpeed() {
+        return armUpSpeed;
+    }
+
+    @Override
+    public double getArmTurboSpeed() {
+        return driverTurboSpeed;
+    }
+
+    @Override
+    public double getArmOperatorTurboSpeed() {
+        return operatorTurboSpeed;
     }
 
 }

--- a/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/mock/MockRobot.java
+++ b/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/mock/MockRobot.java
@@ -8,7 +8,6 @@ import org.usfirst.frc.team1076.udp.ISensorData;
 public class MockRobot implements IRobot {
 	public double left, right, arm, intake, extend;
 	public double lidarSpeed;
-	public double armDownSpeed, armUpSpeed, driverTurboSpeed, operatorTurboSpeed;
 	public boolean brakes;
 	public IntakeRaiseState intakeRaiseState = IntakeRaiseState.Neutral;
 	public SolenoidValue gear = SolenoidValue.Off;
@@ -68,45 +67,4 @@ public class MockRobot implements IRobot {
 	public void setArmExtendSpeed(double speed) {
 		this.extend = speed;
 	}
-	
-    @Override
-    public void setArmSpeed(double speed, boolean turbo) {
-        setArmSpeed(speed, turbo, false); 
-    }
-
-    @Override
-    public void setArmSpeed(double speed, boolean turbo, boolean operatorTurbo) {
-        if (speed > 0) {
-           this.arm  = speed * armUpSpeed;
-        } else {
-            if (turbo) {
-                this.arm = speed * driverTurboSpeed;
-            } else if (operatorTurbo) {
-                this.arm = speed * operatorTurboSpeed;
-            } else {
-                this.arm = speed * armDownSpeed;
-            }
-        }
-    }
-
-    @Override
-    public double getArmDownSpeed() {
-        return armDownSpeed;
-    }
-
-    @Override
-    public double getArmUpSpeed() {
-        return armUpSpeed;
-    }
-
-    @Override
-    public double getArmTurboSpeed() {
-        return driverTurboSpeed;
-    }
-
-    @Override
-    public double getArmOperatorTurboSpeed() {
-        return operatorTurboSpeed;
-    }
-
 }

--- a/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/mock/MockRobot.java
+++ b/FRC1076-2016-Competition/test/org/usfirst/frc/team1076/test/mock/MockRobot.java
@@ -67,5 +67,17 @@ public class MockRobot implements IRobot {
 	public void setArmExtendSpeed(double speed) {
 		this.extend = speed;
 	}
+	// Should the two below do anything?
+    @Override
+    public void setArmSpeed(double speed, boolean turbo) {
+        // TODO Auto-generated method stub
+        
+    }
+
+    @Override
+    public void setArmSpeed(double speed, boolean turbo, boolean operatorTurbo) {
+        // TODO Auto-generated method stub
+        
+    }
 
 }


### PR DESCRIPTION
This adds a HUGE amount of stuff.
- Arm Extension Limit Switches. These stop the motor from moving beyond the arm.
- Custom Lift Arm Speeds. When lowering, the lift arm receives less power then when raising. This evens out raising and lowering to a more manageable speed.
- Turbo and Operator Turbo Modes. When B is held on the driver controller, the lift arm has full power. When B is held on the operator controller, the lift arm has 75% power. Driver takes precedence.
- Swap low and high gear meanings. This was needed so the robot starts in low gear and not high gear.
- Make robot initialize in raised state. ~~**USES A DIRTY HACK**~~ ~~Fixed but not tested yet~~ fixed and tested
- Make the arm follower motor actually an follower motor.
- **Disable autonomous and replace with a simple version**. Done at MARC because the old version was not updated for right side attacking. This temporary autonomous drives backwards and then lowers the arm. That is it.

TODO:
- [ ] This PR was already rebased once, might want to rebase again.
- [ ] Split PR into smaller PRs (more workable)
- [x] Fix + update tests (See #56).
- [x] Investigate intake glitch (See #54)
  - [x] Test fix on actual robot
- [ ] Make whitespace less terrible (See #55)
